### PR TITLE
.NET 9.0 locking fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,7 +74,7 @@
   <!-- Dependencies -->
   <ItemGroup>
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.1.0" />
-    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.3" />
+    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.5" />
     <PackageVersion Include="Blazorise" Version="$(BlazoriseVersion)" />
     <PackageVersion Include="Blazorise.Bootstrap5" Version="$(BlazoriseVersion)" />
     <PackageVersion Include="Blazorise.DataGrid" Version="$(BlazoriseVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,6 +74,7 @@
   <!-- Dependencies -->
   <ItemGroup>
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.1.0" />
+    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.2" />
     <PackageVersion Include="Blazorise" Version="$(BlazoriseVersion)" />
     <PackageVersion Include="Blazorise.Bootstrap5" Version="$(BlazoriseVersion)" />
     <PackageVersion Include="Blazorise.DataGrid" Version="$(BlazoriseVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,7 +74,7 @@
   <!-- Dependencies -->
   <ItemGroup>
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.1.0" />
-    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.2" />
+    <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.3" />
     <PackageVersion Include="Blazorise" Version="$(BlazoriseVersion)" />
     <PackageVersion Include="Blazorise.Bootstrap5" Version="$(BlazoriseVersion)" />
     <PackageVersion Include="Blazorise.DataGrid" Version="$(BlazoriseVersion)" />

--- a/samples/MeshRpc/Services/CounterStorage.cs
+++ b/samples/MeshRpc/Services/CounterStorage.cs
@@ -2,7 +2,7 @@ namespace Samples.MeshRpc.Services;
 
 public static class CounterStorage
 {
-    private static readonly object Lock = new();
+    private static readonly Lock Lock = new();
     private static readonly Dictionary<int, MutableState<Counter>> States = new();
 
     public static Counter Get(int key)

--- a/samples/MiniRpc/Program.cs
+++ b/samples/MiniRpc/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 using ActualLab.Fusion.Server;
 using ActualLab.IO;
 using ActualLab.Rpc;
@@ -103,7 +103,7 @@ public sealed partial record Chat_Post(
 
 public class Chat : IChat
 {
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private List<string> _posts = new();
 
     public virtual Task<List<string>> GetRecentMessages(CancellationToken cancellationToken = default)

--- a/samples/MultiServerRpc/Service.cs
+++ b/samples/MultiServerRpc/Service.cs
@@ -26,7 +26,7 @@ public sealed partial record Chat_Post(
 
 public class Chat(ServerId serverId) : IChat
 {
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private readonly Dictionary<Symbol, List<string>> _chats = new();
 
     private ServerId ServerId { get; } = serverId;

--- a/src/ActualLab.CommandR/Operations/Operation.cs
+++ b/src/ActualLab.CommandR/Operations/Operation.cs
@@ -6,11 +6,7 @@ namespace ActualLab.CommandR.Operations;
 
 public class Operation : IHasUuid, IHasId<Symbol>
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     Symbol IHasId<Symbol>.Id => Uuid;
 
     public long? Index { get; set; }

--- a/src/ActualLab.Core/ActualLab.Core.csproj
+++ b/src/ActualLab.Core/ActualLab.Core.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="Ulid" />
     <PackageReference Include="ZString" />
   </ItemGroup>
+	
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <PackageReference Include="Backport.System.Threading.Lock" />
+  </ItemGroup>	
 
   <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard2.0'))">
     <PackageReference Include="MemoryPack.Core" />

--- a/src/ActualLab.Core/Async/ProcessorBase.cs
+++ b/src/ActualLab.Core/Async/ProcessorBase.cs
@@ -4,11 +4,7 @@ public abstract class ProcessorBase : IAsyncDisposable, IDisposable, IHasWhenDis
 {
     private volatile Task? _disposeTask;
 
-#if NET9_0_OR_GREATER
-    protected Lock Lock { get; } = new();
-#else
-    protected object Lock { get; } = new();
-#endif
+    protected Lock Lock = new();
     protected CancellationTokenSource StopTokenSource { get; }
 
     public CancellationToken StopToken { get; }

--- a/src/ActualLab.Core/Collections/MutableDictionary.cs
+++ b/src/ActualLab.Core/Collections/MutableDictionary.cs
@@ -24,11 +24,7 @@ public class MutableDictionary<TKey, TValue>(ImmutableDictionary<TKey, TValue> i
     : IMutableDictionary<TKey, TValue>
     where TKey : notnull
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private volatile ImmutableDictionary<TKey, TValue> _items = items;
 
     public ImmutableDictionary<TKey, TValue> Items {

--- a/src/ActualLab.Core/Collections/MutableList.cs
+++ b/src/ActualLab.Core/Collections/MutableList.cs
@@ -21,11 +21,7 @@ public interface IMutableList<T> : IReadOnlyMutableList<T>, IList<T>
 
 public class MutableList<T>(ImmutableList<T> items) : IMutableList<T>
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private volatile ImmutableList<T> _items = items;
 
     public ImmutableList<T> Items {

--- a/src/ActualLab.Core/Collections/MutablePropertyBag.cs
+++ b/src/ActualLab.Core/Collections/MutablePropertyBag.cs
@@ -31,11 +31,7 @@ public interface IMutablePropertyBag : IReadOnlyPropertyBag
 [Newtonsoft.Json.JsonObject(Newtonsoft.Json.MemberSerialization.OptOut)]
 public sealed partial class MutablePropertyBag : IMutablePropertyBag
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private PropertyBag _snapshot;
 
     public event Action? Changed;

--- a/src/ActualLab.Core/Diagnostics/Samplers.cs
+++ b/src/ActualLab.Core/Diagnostics/Samplers.cs
@@ -86,11 +86,7 @@ public sealed record Sampler(
         if (probability >= 1)
             return Always;
 
-#if NET9_0_OR_GREATER
         Lock @lock = new();
-#else
-        object @lock = new();
-#endif
         var rnd = new Random();
         var maxIntBasedLimit = (int)((1d + int.MaxValue) * probability - 1);
         var sampler = new Sampler(nameof(Random), probability, () => {
@@ -127,11 +123,7 @@ public sealed record Sampler(
         if (probability >= 1)
             return Always;
 
-#if NET9_0_OR_GREATER
         Lock @lock = new();
-#else
-        object @lock = new();
-#endif
         var rnd = new Random();
         var stepSize = 1d / probability;
         var maxIntBasedLimit = (int)((1d + int.MaxValue) * probability - 1);

--- a/src/ActualLab.Core/Generators/RandomStringGenerator.cs
+++ b/src/ActualLab.Core/Generators/RandomStringGenerator.cs
@@ -14,7 +14,7 @@ public class RandomStringGenerator : Generator<string>, IDisposable
 
     protected readonly RandomNumberGenerator Rng;
     // ReSharper disable once InconsistentlySynchronizedField
-    protected object Lock => Rng;
+    protected Lock Lock = new();
 
     public string Alphabet { get; }
     public int Length { get; }

--- a/src/ActualLab.Core/IO/ConsoleExt.cs
+++ b/src/ActualLab.Core/IO/ConsoleExt.cs
@@ -4,11 +4,7 @@ namespace ActualLab.IO;
 
 public static class ConsoleExt
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static TaskScheduler? _scheduler;
 
     public static TaskScheduler Scheduler {

--- a/src/ActualLab.Core/LazySlim.cs
+++ b/src/ActualLab.Core/LazySlim.cs
@@ -32,6 +32,7 @@ public static class LazySlim
 
 public sealed class LazySlim<TValue> : ILazySlim<TValue>
 {
+    private readonly Lock _syncLock = new();
     private Func<TValue>? _factory;
     private TValue _value;
 
@@ -39,7 +40,7 @@ public sealed class LazySlim<TValue> : ILazySlim<TValue>
         get {
             // Double-check locking
             if (_factory == null) return _value;
-            lock (this) {
+            lock (_syncLock) {
                 if (_factory == null) return _value;
                 _value = _factory.Invoke();
                 _factory = null;

--- a/src/ActualLab.Core/Mathematics/PrimeSieve.cs
+++ b/src/ActualLab.Core/Mathematics/PrimeSieve.cs
@@ -2,11 +2,7 @@ namespace ActualLab.Mathematics;
 
 public class PrimeSieve
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static PrimeSieve? _instance;
 
     private readonly int _limitSqrt;

--- a/src/ActualLab.Core/Net/RetryDelayer.cs
+++ b/src/ActualLab.Core/Net/RetryDelayer.cs
@@ -5,11 +5,7 @@ public class RetryDelayer : IRetryDelayer
     private CancellationTokenSource _cancelDelaysCts = new();
 
     private MomentClock? _clock;
-#if NET9_0_OR_GREATER
     protected readonly Lock Lock = new();
-#else
-    protected readonly object Lock = new();
-#endif
 
     public Func<MomentClock> ClockProvider { get; init; } = static () => CpuClock.Instance;
     public MomentClock Clock => _clock ??= ClockProvider.Invoke();

--- a/src/ActualLab.Core/OS/HardwareInfo.cs
+++ b/src/ActualLab.Core/OS/HardwareInfo.cs
@@ -3,11 +3,7 @@ namespace ActualLab.OS;
 public static class HardwareInfo
 {
     private const int RefreshIntervalTicks = 30_000; // Tick = millisecond
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static volatile int _processorCount;
     private static volatile int _processorCountPo2;
     private static volatile int _lastRefreshTicks =

--- a/src/ActualLab.Core/Requirement.cs
+++ b/src/ActualLab.Core/Requirement.cs
@@ -26,11 +26,7 @@ public abstract record Requirement<
 {
     private const string MustExistFieldOrPropertyName = "MustExist";
     // ReSharper disable once StaticMemberInGenericType
-#if NET9_0_OR_GREATER
     private static readonly Lock MustExistLock = new();
-#else
-    private static readonly object MustExistLock = new();
-#endif
     private static volatile Requirement<T>? _mustExist;
 
     public static Requirement<T> MustExist {

--- a/src/ActualLab.Core/StaticLog.cs
+++ b/src/ActualLab.Core/StaticLog.cs
@@ -2,11 +2,7 @@ namespace ActualLab;
 
 public static class StaticLog
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static readonly ConcurrentDictionary<object, ILogger> Cache = new();
     private static volatile ILoggerFactory _factory = NullLoggerFactory.Instance;
 

--- a/src/ActualLab.Core/Time/TickSource.cs
+++ b/src/ActualLab.Core/Time/TickSource.cs
@@ -6,11 +6,7 @@ public sealed class TickSource(TimeSpan period)
     // On other OSes it will be ~= t = N*NativeTimerPeriod so that t >= 15ms.
     public static TickSource Default { get; set; } = new(TimeSpan.FromMilliseconds(15));
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private volatile Task _whenNextTick = Task.CompletedTask;
 
     public TimeSpan Period { get; } = period > TimeSpan.Zero

--- a/src/ActualLab.Core/Time/TimerSet.cs
+++ b/src/ActualLab.Core/Time/TimerSet.cs
@@ -14,11 +14,7 @@ public record TimerSetOptions
 public sealed class TimerSet<TTimer> : WorkerBase
     where TTimer : notnull
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private readonly Action<TTimer>? _fireHandler;
     private readonly RadixHeapSet<TTimer> _timers = new(45);
     private readonly Moment _start;

--- a/src/ActualLab.Core/Trimming/CodeKeeper.cs
+++ b/src/ActualLab.Core/Trimming/CodeKeeper.cs
@@ -5,11 +5,7 @@ namespace ActualLab.Trimming;
 
 public abstract class CodeKeeper
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static readonly List<Action> Actions = new();
     private static readonly HashSet<Action> ActionSet = new();
 

--- a/src/ActualLab.Fusion.Blazor.Authentication/AuthStateProvider.cs
+++ b/src/ActualLab.Fusion.Blazor.Authentication/AuthStateProvider.cs
@@ -21,11 +21,7 @@ public sealed class AuthStateProvider : AuthenticationStateProvider, IDisposable
         }
     };
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private Session? _session;
     private volatile Task<AuthState> _authStateTask;
     private volatile Task<AuthenticationState> _authenticationStateTask;

--- a/src/ActualLab.Fusion.EntityFramework/Sharding/DbShardRegistry.cs
+++ b/src/ActualLab.Fusion.EntityFramework/Sharding/DbShardRegistry.cs
@@ -20,7 +20,7 @@ public interface IDbShardRegistry<TContext> : IDbShardRegistry;
 
 public class DbShardRegistry<TContext> : IDbShardRegistry<TContext>, IDisposable
 {
-    protected readonly object Lock = new();
+    protected readonly Lock Lock = new();
     private readonly MutableState<ImmutableHashSet<DbShard>> _shards;
     private readonly MutableState<ImmutableHashSet<DbShard>> _usedShards;
     private readonly ComputedState<ImmutableHashSet<DbShard>> _eventProcessorShards;

--- a/src/ActualLab.Fusion/Client/Caching/RemoteComputedCache.Static.cs
+++ b/src/ActualLab.Fusion/Client/Caching/RemoteComputedCache.Static.cs
@@ -6,11 +6,7 @@ namespace ActualLab.Fusion.Client.Caching;
 public partial class RemoteComputedCache
 {
     private static Func<ComputeMethodInput, RpcPeer, Task>? _updateDelayer;
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
 
     public static Func<ComputeMethodInput, RpcPeer, Task>? UpdateDelayer {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ActualLab.Fusion/Computed.cs
+++ b/src/ActualLab.Fusion/Computed.cs
@@ -35,10 +35,7 @@ public abstract partial class Computed(ComputedOptions options, ComputedInput in
     // ReSharper disable once InconsistentNaming
     private InvalidatedHandlerSet _invalidated;
 
-    protected object Lock {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => this;
-    }
+    protected Lock Lock = new();
 
     protected ComputedFlags Flags {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ActualLab.Fusion/ComputedRegistry.cs
+++ b/src/ActualLab.Fusion/ComputedRegistry.cs
@@ -24,11 +24,7 @@ public sealed class ComputedRegistry : IDisposable
         public GCHandlePool? GCHandlePool { get; init; } = null;
     }
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private readonly ConcurrentDictionary<ComputedInput, GCHandle> _storage;
     private readonly GCHandlePool _gcHandlePool;
     private StochasticCounter _opCounter;

--- a/src/ActualLab.Fusion/ComputedSource.cs
+++ b/src/ActualLab.Fusion/ComputedSource.cs
@@ -23,7 +23,7 @@ public class ComputedSource<T> : ComputedInput,
     private ILogger? _log;
 
     protected AsyncLock AsyncLock { get; }
-    protected object Lock => AsyncLock;
+    protected Lock Lock = new();
     protected ILogger Log => _log ??= Services.LogFor(GetType());
 
     public IServiceProvider Services { get; }

--- a/src/ActualLab.Fusion/Configuration/FusionDefaults.cs
+++ b/src/ActualLab.Fusion/Configuration/FusionDefaults.cs
@@ -4,11 +4,7 @@ namespace ActualLab.Fusion;
 
 public static class FusionDefaults
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static FusionMode _mode;
 
     public static FusionMode Mode {

--- a/src/ActualLab.Fusion/Diagnostics/FusionMonitor.cs
+++ b/src/ActualLab.Fusion/Diagnostics/FusionMonitor.cs
@@ -6,11 +6,7 @@ namespace ActualLab.Fusion.Diagnostics;
 
 public sealed class FusionMonitor : WorkerBase
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     // Cached delegates
     private readonly Action<Computed, bool> _onAccess;

--- a/src/ActualLab.Fusion/Operations/OperationCompletionNotifier.cs
+++ b/src/ActualLab.Fusion/Operations/OperationCompletionNotifier.cs
@@ -22,7 +22,7 @@ public class OperationCompletionNotifier : IOperationCompletionNotifier
     protected HostId HostId { get; }
     protected IOperationCompletionListener[] OperationCompletionListeners { get; }
     protected RecentlySeenMap<Symbol, Unit> RecentlySeenUuids { get; }
-    protected object Lock => RecentlySeenUuids;
+    protected Lock Lock = new();
     protected MomentClock Clock { get; }
     protected ILogger Log { get; }
 

--- a/src/ActualLab.Fusion/State/State.cs
+++ b/src/ActualLab.Fusion/State/State.cs
@@ -63,7 +63,7 @@ public abstract class State<T> : ComputedInput,
 
     protected ComputedOptions ComputedOptions { get; private set; } = null!;
     protected AsyncLock AsyncLock { get; } = new(LockReentryMode.CheckedFail);
-    protected object Lock => AsyncLock;
+    protected Lock Lock = new();
     protected ILogger Log => _log ??= Services.LogFor(GetType());
 
     public IServiceProvider Services { get; }

--- a/src/ActualLab.Fusion/State/StateFactory.cs
+++ b/src/ActualLab.Fusion/State/StateFactory.cs
@@ -4,11 +4,7 @@ namespace ActualLab.Fusion;
 
 public class StateFactory(IServiceProvider services) : IHasServices
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static StateFactory? _default;
 
     public static StateFactory Default {

--- a/src/ActualLab.Redis/RedisComponent.cs
+++ b/src/ActualLab.Redis/RedisComponent.cs
@@ -5,11 +5,7 @@ namespace ActualLab.Redis;
 
 public sealed class RedisComponent<T>(RedisConnector connector, Func<IConnectionMultiplexer, T> factory)
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private volatile Task<Temporary<T>>? _resultTask;
 
     public RedisComponent(RedisDb redisDb, Func<IConnectionMultiplexer, T> factory)

--- a/src/ActualLab.Redis/RedisConnector.cs
+++ b/src/ActualLab.Redis/RedisConnector.cs
@@ -4,11 +4,7 @@ namespace ActualLab.Redis;
 
 public class RedisConnector
 {
-#if NET9_0_OR_GREATER
     protected readonly Lock Lock = new();
-#else
-    protected readonly object Lock = new();
-#endif
     protected readonly Func<Task<IConnectionMultiplexer>> MultiplexerFactory;
     protected volatile AsyncState<Task<Temporary<IConnectionMultiplexer>>?> State = new(null, false);
     protected volatile CancellationTokenSource? GoneTokenSource;

--- a/src/ActualLab.Rpc/Configuration/RpcCallTypeRegistry.cs
+++ b/src/ActualLab.Rpc/Configuration/RpcCallTypeRegistry.cs
@@ -5,11 +5,7 @@ namespace ActualLab.Rpc;
 
 public static class RpcCallTypeRegistry
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static volatile (Type? InboundCallType, Type? OutboundCallType)[] _callTypes;
 
     static RpcCallTypeRegistry()

--- a/src/ActualLab.Rpc/Configuration/RpcConfiguration.cs
+++ b/src/ActualLab.Rpc/Configuration/RpcConfiguration.cs
@@ -5,11 +5,7 @@ namespace ActualLab.Rpc;
 
 public class RpcConfiguration
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private IDictionary<Type, RpcServiceBuilder> _services = new Dictionary<Type, RpcServiceBuilder>();
     private RpcServiceMode _defaultServiceMode;
 

--- a/src/ActualLab.Rpc/Configuration/RpcDefaults.cs
+++ b/src/ActualLab.Rpc/Configuration/RpcDefaults.cs
@@ -4,11 +4,7 @@ namespace ActualLab.Rpc;
 
 public static class RpcDefaults
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static VersionSet? _apiPeerVersions;
     private static VersionSet? _backendPeerVersions;
     private static RpcMode _mode;

--- a/src/ActualLab.Rpc/Infrastructure/RpcCall.cs
+++ b/src/ActualLab.Rpc/Infrastructure/RpcCall.cs
@@ -2,10 +2,7 @@ namespace ActualLab.Rpc.Infrastructure;
 
 public abstract class RpcCall(RpcMethodDef methodDef)
 {
-    protected object Lock {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => this;
-    }
+    protected Lock Lock = new();
 
     public abstract string DebugTypeName { get; }
 

--- a/src/ActualLab.Rpc/Infrastructure/RpcCallStage.cs
+++ b/src/ActualLab.Rpc/Infrastructure/RpcCallStage.cs
@@ -2,11 +2,7 @@ namespace ActualLab.Rpc.Infrastructure;
 
 public static class RpcCallStage
 {
-#if NET9_0_OR_GREATER
     private static readonly Lock Lock = new();
-#else
-    private static readonly object Lock = new();
-#endif
     private static Dictionary<int, string> _callStageNames = new() {
         { ResultReady, nameof(ResultReady) },
         { ResultReady | Unregistered, "*" + nameof(ResultReady) },

--- a/src/ActualLab.Rpc/RpcPeer.cs
+++ b/src/ActualLab.Rpc/RpcPeer.cs
@@ -412,11 +412,11 @@ public abstract class RpcPeer : WorkerBase, IHasId<Guid>
         RpcPeerConnectionState newState,
         AsyncState<RpcPeerConnectionState>? expectedState = null)
     {
-        Monitor.Enter(Lock);
+        Lock.Enter();
         var connectionState = _connectionState;
         var oldState = connectionState.Value;
         if ((expectedState != null && connectionState != expectedState) || ReferenceEquals(newState, oldState)) {
-            Monitor.Exit(Lock);
+            Lock.Exit();
             return connectionState;
         }
         Exception? terminalError = null;
@@ -427,7 +427,7 @@ public abstract class RpcPeer : WorkerBase, IHasId<Guid>
             }
             var nextConnectionState = connectionState.TrySetNext(newState);
             if (ReferenceEquals(nextConnectionState, connectionState)) {
-                Monitor.Exit(Lock);
+                Lock.Exit();
                 return connectionState;
             }
             _connectionState = connectionState = nextConnectionState;
@@ -455,7 +455,7 @@ public abstract class RpcPeer : WorkerBase, IHasId<Guid>
                 // Complete the old Channel
                 oldState.Sender?.TryComplete(newState.Error);
             }
-            Monitor.Exit(Lock);
+            Lock.Exit();
 
             // The code below is responsible solely for logging - all important stuff is already done
             if (terminalError != null)

--- a/src/ActualLab.Rpc/RpcStream.cs
+++ b/src/ActualLab.Rpc/RpcStream.cs
@@ -70,11 +70,7 @@ public abstract partial class RpcStream : IRpcObject
 [Newtonsoft.Json.JsonObject(Newtonsoft.Json.MemberSerialization.OptOut)]
 public sealed partial class RpcStream<T> : RpcStream, IAsyncEnumerable<T>
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private readonly IAsyncEnumerable<T>? _localSource;
     private Channel<T>? _remoteChannel;
     private long _nextIndex;

--- a/src/ActualLab.Rpc/Testing/RpcTestConnection.cs
+++ b/src/ActualLab.Rpc/Testing/RpcTestConnection.cs
@@ -5,11 +5,7 @@ namespace ActualLab.Rpc.Testing;
 
 public class RpcTestConnection
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private volatile AsyncState<ChannelPair<RpcMessage>?> _channels = new(null, true);
     private RpcClientPeer? _clientPeer;
     private RpcServerPeer? _serverPeer;

--- a/src/ActualLab.Testing/Output/TestOutputCapture.cs
+++ b/src/ActualLab.Testing/Output/TestOutputCapture.cs
@@ -8,11 +8,7 @@ namespace ActualLab.Testing.Output;
 public class TestOutputCapture(TestTextWriter? downstream = null)
     : IStandardStreamWriter, ITestOutputHelper
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     public StringBuilder StringBuilder = new();
     public TestTextWriter? Downstream { get; set; } = downstream;
 

--- a/src/ActualLab.Testing/ThreadSafe.cs
+++ b/src/ActualLab.Testing/ThreadSafe.cs
@@ -2,11 +2,7 @@ namespace ActualLab.Testing;
 
 public class ThreadSafe<T>
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private T _value;
 
     public T Value {

--- a/tests/ActualLab.Fusion.Tests/FusionTestBase.cs
+++ b/tests/ActualLab.Fusion.Tests/FusionTestBase.cs
@@ -26,11 +26,7 @@ public abstract class FusionTestBase : RpcTestBase
 {
     private static readonly AsyncLock InitializeLock = new(LockReentryMode.CheckedFail);
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
     private IRemoteComputedCache? _remoteComputedCache;
 
     public FusionTestDbType DbType { get; set; } = TestRunnerInfo.IsBuildAgent()

--- a/tests/ActualLab.Tests/CommandR/Services/MathService.cs
+++ b/tests/ActualLab.Tests/CommandR/Services/MathService.cs
@@ -11,11 +11,7 @@ public interface IMathService : ICommandService, IRequiresFullProxy
 
 public class MathService(IServiceProvider services) : ServiceBase(services), IMathService
 {
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     private ICommander Commander { get; } = services.Commander();
 


### PR DESCRIPTION
Fixes locking issues in .NET 9.0. You should not use System.Threading.Lock in conjunction with Monitor since the .NET 9.0 version is not Monitor-based.