### PR TITLE
 fix(ts/rpc): parse camelCase JSON handshake fields

### DIFF
--- a/ts/packages/rpc/src/rpc-peer.ts
+++ b/ts/packages/rpc/src/rpc-peer.ts
@@ -474,17 +474,29 @@ export abstract class RpcPeer {
         if (method === RpcSystemCalls.handshake) {
             const raw = args[0];
             if (raw !== undefined) {
-                // .NET's RpcHandshake is [MessagePackObject(Key)] — serialized
-                // as a 5-element array in msgpack. In JSON it's an object with
-                // named properties. Normalize both shapes here.
-                const handshake = Array.isArray(raw)
+                // .NET's MessagePack path serializes RpcHandshake as a 5-element
+                // [Key(N)] array; the JSON (text) path emits an object. ASP.NET's
+                // System.Text.Json defaults (JsonSerializerDefaults.Web) lower-case
+                // the first letter, so the JSON keys are camelCase (`index`,
+                // `remoteHubId`) — NOT the PascalCase the property names suggest.
+                // Read both cases so the text format's `Index` survives; without
+                // this it parses as `undefined`, `_remoteHandshakeIndex` falls back
+                // to 0, and every `$sys.Reconnect` is rejected by the server with
+                // "own handshake index N != 0" (and peer-change detection breaks).
+                const obj = (raw ?? {}) as Record<string, unknown>;
+                const handshake: RemoteHandshake = Array.isArray(raw)
                     ? {
                         RemotePeerId: raw[0] as string | undefined,
                         RemoteHubId: raw[2] as string | undefined,
                         ProtocolVersion: raw[3] as number | undefined,
                         Index: raw[4] as number | undefined,
                     }
-                    : raw as RemoteHandshake;
+                    : {
+                        RemotePeerId: (obj.RemotePeerId ?? obj.remotePeerId) as string | undefined,
+                        RemoteHubId: (obj.RemoteHubId ?? obj.remoteHubId) as string | undefined,
+                        ProtocolVersion: (obj.ProtocolVersion ?? obj.protocolVersion) as number | undefined,
+                        Index: (obj.Index ?? obj.index) as number | undefined,
+                    };
                 this._onHandshakeReceived(handshake);
             }
             return;


### PR DESCRIPTION
  ## Problem

  Over the **text (`json5np`) transport**, the TS RPC client fails to read the
  server's handshake fields, because the object-form parse in `RpcPeer._handleMessage`
  assumes PascalCase property names:

  ```ts
  const handshake = Array.isArray(raw)
      ? { RemotePeerId: raw[0], RemoteHubId: raw[2], ProtocolVersion: raw[3], Index: raw[4] }
      : raw as RemoteHandshake;   // assumes raw.Index / raw.RemoteHubId
```
  But the .NET server serializes RpcHandshake through System.Text.Json with
  JsonSerializerDefaults.Web, so the wire shape is camelCase:

  {"remotePeerId":"…","remoteApiVersionSet":{…},"remoteHubId":"…","protocolVersion":2,"index":1}

  So handshake.Index and handshake.RemoteHubId read back as undefined.

  Consequences (JSON transport only)

  1. Reconnect is permanently rejected. _remoteHandshakeIndex falls back to 0,
  so every $sys.Reconnect echoes handshakeIndex=0. The server's
  RpcSystemCalls.Reconnect check (ownHandshake.Index != handshakeIndex) throws
  Too late for this reconnect round: own handshake index N != 0 on every reconnect,
  forcing the resend-all fallback and logging an error each time.
  2. Peer-change detection never fires — it keys off RemoteHubId, which is also undefined,
  so _lastRemoteHubId is never set and peerChanged stays false across genuine server restarts.

  The MessagePack transport is unaffected — it reads positional [Key(N)] array
  elements (raw[4]), so this only surfaces on the text format.

  Repro

  A TS client (json5np) against a v13 .NET server, with active compute subscriptions,
  forced to reconnect:

  [handshake] index=1,2,3   ← server sends, camelCase, incrementing
  [handshake] Index=undefined ← client parse (PascalCase miss)
  [reconnect] $sys.Reconnect handshakeIndex=0
  server: RpcException: Too late for this reconnect round: own handshake index N != 0

  After the fix the client echoes handshakeIndex=2,3 matching the server's sequence,
  and the server-side error disappears.

  Fix

  Parse both casings for the object form (PascalCase first, camelCase fallback). The
  MessagePack array path is unchanged.

  Notes

  - Discovered while running a React client on the text transport against
  ActualLab.Fusion 13.0.12.
  - rpc-reconnect-wire-format.test.ts still passes (8/8). A dedicated unit test for
  camelCase handshake parsing could be added if desired — happy to follow up.